### PR TITLE
리눅스 환경 맞춤

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,23 +1,26 @@
 # backend
 
 ### 개발 환경
+
 - Build Tool: Gradle
 - Framework: Spring Boot 3.2.5
 - Programming Language: Java, JDK 17
-- ORM: MyBatis 
+- ORM: MyBatis
 - DBMS: MySQL
 
-* * *
+---
+
 ### DDL script
+
 ```sql
-CREATE TABLE Member (
+CREATE TABLE member (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     email VARCHAR(255) NOT NULL,
     username VARCHAR(255) NOT NULL,
     password VARCHAR(255) NOT NULL
 );
 
-CREATE TABLE Notice (
+CREATE TABLE notice (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     title VARCHAR(255) NOT NULL,
     content TEXT NOT NULL,

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -4,9 +4,9 @@ spring:
   # MySQL DataSource
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/noticeboard?serverTimezone=UTC
+    url: jdbc:mysql://localhost:13308/vue3_board?serverTimezone=UTC
     username: root
-    password: 1234
+    password: 9999
 
 # Mapper Xml Location
 mybatis:
@@ -22,6 +22,6 @@ spring:
       on-profile: test # 환경이름설정
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/testboard?serverTimezone=UTC
+    url: jdbc:mysql://localhost:13308/vue3_board?serverTimezone=UTC
     username: root
-    password: 1234
+    password: 9999

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -4,7 +4,7 @@ spring:
   # MySQL DataSource
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:13308/vue3_board?serverTimezone=UTC
+    url: jdbc:mysql://localhost:3306/testboard?serverTimezone=UTC
     username: root
     password: 9999
 
@@ -22,6 +22,6 @@ spring:
       on-profile: test # 환경이름설정
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:13308/vue3_board?serverTimezone=UTC
+    url: jdbc:mysql://localhost:3306/testboard?serverTimezone=UTC
     username: root
-    password: 9999
+    password: 1234


### PR DESCRIPTION
Backend README.md 
파일에 DDL의 Table 명이 대소문자가 섞여있어 리눅스 환경에서는 
쿼리문이 table을 못찾네요 ㅠㅠ

https://leejaedoo.github.io/table_name/ 

설명글 달린 블로그 글 입니다!